### PR TITLE
[Feature] retrieve l18n Description from currentWeather by openweatherapi

### DIFF
--- a/Classes/Domain/Model/CurrentWeather.php
+++ b/Classes/Domain/Model/CurrentWeather.php
@@ -23,6 +23,11 @@ class CurrentWeather extends AbstractEntity
      */
     protected $name = '';
 
+     /**
+     * @var string
+     */
+    protected $description = '';
+
     /**
      * @var \DateTime
      */
@@ -96,6 +101,16 @@ class CurrentWeather extends AbstractEntity
     public function setName(string $name): void
     {
         $this->name = $name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
     }
 
     public function getMeasureTimestamp(): ?\DateTime

--- a/Classes/Task/OpenWeatherMapTaskAdditionalFieldProvider.php
+++ b/Classes/Task/OpenWeatherMapTaskAdditionalFieldProvider.php
@@ -69,6 +69,7 @@ class OpenWeatherMapTaskAdditionalFieldProvider extends AbstractAdditionalFieldP
         'city',
         'country',
         'apiKey',
+        'languages',
         'clearCache',
         'errorNotification',
         'emailSenderName',
@@ -163,6 +164,13 @@ size="30" placeholder="' . WeatherUtility::translate('placeholder.record_storage
         $additionalFields[$fieldID] = [
             'code' => $fieldCode,
             'label' => 'LLL:EXT:weather2/Resources/Private/Language/locallang_scheduler_openweatherapi.xlf:api_key',
+        ];
+
+        $fieldID = 'languages';
+        $fieldCode = '<input type="text" class="form-control" name="tx_scheduler[languages]" id="' . $fieldID . '" value="' . $taskInfo['languages'] . '" size="120" />';
+        $additionalFields[$fieldID] = [
+            'code' => $fieldCode,
+            'label' => 'LLL:EXT:weather2/Resources/Private/Language/locallang_scheduler_openweatherapi.xlf:languages',
         ];
 
         $fieldID = 'clearCache';
@@ -313,6 +321,7 @@ size="30" placeholder="' . WeatherUtility::translate('placeholder.record_storage
         $task->recordStoragePage = (int)($submittedData['recordStoragePage'] ?? 0);
         $task->country = $submittedData['country'] ?? '';
         $task->apiKey = $submittedData['apiKey'] ?? '';
+        $task->languages = $submittedData['languages'] ?? '';
         $task->clearCache = $submittedData['clearCache'] ?? '0';
         $task->errorNotification = $submittedData['errorNotification'] ?? '';
         $task->emailSenderName = $submittedData['emailSenderName'] ?? '';

--- a/Configuration/TCA/tx_weather2_domain_model_currentweather.php
+++ b/Configuration/TCA/tx_weather2_domain_model_currentweather.php
@@ -11,6 +11,10 @@ return [
         'crdate' => 'crdate',
         'rootLevel' => -1,
         'delete' => 'deleted',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
@@ -23,9 +27,39 @@ return [
         ],
     ],
     'types' => [
-        '1' => ['showitem' => 'name, measure_timestamp, temperature_c, pressure_hpa, humidity_percentage, min_temp_c, max_temp_c, wind_speed_m_p_s, wind_direction_deg, pop_percentage, rain_volume, snow_volume, clouds_percentage, icon, serialized_array, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime'],
+        '1' => ['showitem' => 'name, description, measure_timestamp, temperature_c, pressure_hpa, humidity_percentage, min_temp_c, max_temp_c, wind_speed_m_p_s, wind_direction_deg, pop_percentage, rain_volume, snow_volume, clouds_percentage, icon, serialized_array, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime'],
     ],
     'columns' => [
+        'sys_language_uid' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'config' => [
+                'type' => 'language',
+            ],
+        ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'config' => [
+                'type' => 'group',
+                'allowed' => 'tx_weather2_domain_model_currentweather',
+                'size' => 1,
+                'maxitems' => 1,
+                'minitems' => 0,
+                'default' => 0,
+            ],
+        ],
+        'l10n_source' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => '',
+            ],
+        ],
         'starttime' => [
             'exclude' => 1,
             'label' => 'EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
@@ -59,6 +93,15 @@ return [
         'name' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:weather2/Resources/Private/Language/locallang_db.xlf:tx_weather2_domain_model_currentweather.name',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+                'eval' => 'trim',
+            ],
+        ],
+        'description' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:weather2/Resources/Private/Language/locallang_db.xlf:tx_weather2_domain_model_currentweather.description',
             'config' => [
                 'type' => 'input',
                 'size' => 30,

--- a/Resources/Private/Language/de.locallang_scheduler_openweatherapi.xlf
+++ b/Resources/Private/Language/de.locallang_scheduler_openweatherapi.xlf
@@ -20,6 +20,10 @@
 				<source>API-Key</source>
 				<target>API-Key</target>
 			</trans-unit>
+			<trans-unit id="languages">
+				<source>Language IDs (comma separated list with IDs)</source>
+				<target>Sprach IDs (kommaseparierte Liste mit IDs)</target>
+			</trans-unit>
 			<trans-unit id="clear_cache">
 				<source>Clear cache for pages (comma separated list with IDs)</source>
 				<target>Leere Cache für Seiten (kommaseparierte Liste mit IDs)</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -10,6 +10,9 @@
 			<trans-unit id="tx_weather2_domain_model_currentweather.name">
 				<source>Name</source>
 			</trans-unit>
+			<trans-unit id="tx_weather2_domain_model_currentweather.description">
+				<source>Description</source>
+			</trans-unit>
 			<trans-unit id="tx_weather2_domain_model_currentweather.measure_timestamp">
 				<source>Measure Timestamp</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_scheduler_openweatherapi.xlf
+++ b/Resources/Private/Language/locallang_scheduler_openweatherapi.xlf
@@ -16,6 +16,9 @@
 			<trans-unit id="api_key">
 				<source>API-Key</source>
 			</trans-unit>
+			<trans-unit id="languages">
+				<source>Language IDs (comma separated list with IDs)</source>
+			</trans-unit>
 			<trans-unit id="clear_cache">
 				<source>Clear cache for pages (comma separated list with IDs)</source>
 			</trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,6 +3,7 @@
 #
 CREATE TABLE tx_weather2_domain_model_currentweather (
 	name varchar(255) DEFAULT '' NOT NULL,
+	description varchar(255) DEFAULT '' NOT NULL,
 	measure_timestamp int(11) DEFAULT '0' NOT NULL,
 	temperature_c double(4,2) DEFAULT '0.0' NOT NULL,
 	pressure_hpa double(4,2) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
### Why did I need this
We used a custom openweatherapi integration that simply retrieved weather and description. But the implamantation was kindy sloppy so I checked out your extension. Everything was fine but you do not retrieve the description text and there was no documentation how I could simply translate by the icon => https://openweathermap.org/weather-conditions
But by analysing the data that we collected for a long time I retrieved following descriptions per icon (as file because it is a lot per code...) => 
[openweaterapi-weathercodes.txt](https://github.com/jweiland-net/weather2/files/14523889/openweaterapi-weathercodes.txt)

### Implementation
First of all I added a new field "languages" to the scheduler task "weather2". This is a comma separated list with IDs of the used languages of the page and per default it is -1 if empty. In the scheduler I added the lang param to the url (default: en), so I can switch the language as needed. In a loop I iterate over every ID that the user entered in the scheduler and via the site finder I retrieve the twoLetterIsoCode of the language, that will be sent to openweater.

### Impact
Obviously as we added new language fields, we need to update the database structure. Furthermore the Scheduler task has to be executed one time to update those fields to be correctly displayed in the frontend.

### Future
I have seen that the weather alert has hardcoded translations in it. Maybe the API retrieves the description the same way and you could implement it like I did, so you get the same translation as openweather, as seen in my .txt file with all of the codes, openweather uses different descriptions for the same code... 